### PR TITLE
add MariaDB to documentation 

### DIFF
--- a/docs/3/modules/_sql_table.md
+++ b/docs/3/modules/_sql_table.md
@@ -4,6 +4,6 @@ The following SQL modules are included with InspIRCd:
 
 Engine  | Module                                    | Description
 ------- | ----------------------------------------- | -----------
-mysql   | [mysql](/{{ version }}/modules/mysql)     | Queries a [MySQL](https://www.mysql.com) database.
+mysql   | [mysql](/{{ version }}/modules/mysql)     | Queries a [MariaDB](https://www.mariadb.org)  or [MySQL](https://www.mysql.com) database.
 pgsql   | [pgsql](/{{ version }}/modules/pgsql)     | Queries a [PostgreSQL](https://www.postgresql.org) database.
 sqlite3 | [sqlite3](/{{ version }}/modules/sqlite3) | Queries an [SQLite](https://www.sqlite.org) database.

--- a/docs/3/modules/mysql.yml
+++ b/docs/3/modules/mysql.yml
@@ -4,19 +4,19 @@ depends_on:
   what: a third-party library ([libmysqlclient](https://dev.mysql.com/downloads/connector/c/))
 
 description: |-
-  This module provides the ability for SQL modules to query a MySQL database.
+  This module provides the ability for SQL modules to query a MariaDB or MySQL database.
 
 configuration:
 - name: database
   description: |-
-    The `<database>` tag defines a MySQL database to connect to. This tag can be defined as many times as required.
+    The `<database>` tag defines a MariaDB or MySQL database to connect to. This tag can be defined as many times as required.
   attributes:
   - name: module
     type: Text
     required: true
     default: null
     description: |-
-      *This MUST be set to "mysql" to connect to a MySQL database.*
+      *This MUST be set to "mysql" to connect to a MariaDB or MySQL database.*
   - name: id
     type: Text
     required: true
@@ -28,44 +28,44 @@ configuration:
     required: true
     default: null
     description: |-
-      The hostname or IP address of a MySQL server.
+      The hostname or IP address of a MariaDB or MySQL server.
   - name: port
     type: Number
     required: true
     default: null
     description: |-
-      The port on which the MySQL server is listening.
+      The port on which the MariaDB or MySQL server is listening.
   - name: user
     type: Text
     required: true
     default: null
     description: |-
-      The username to log into the MySQL server with.
+      The username to log into the MariaDB or MySQL server with.
   - name: pass
     type: Text
     required: true
     default: null
     description: |-
-      The password to log into the MySQL server with.
+      The password to log into the MariaDB or MySQL server with.
   - name: name
     type: Text
     required: true
     default: null
     description: |-
-      The name of the MySQL database to use.
+      The name of the MariaDB or MySQL database to use.
   - name: charset
     type: Text
     required: false
     default: null
     description: |-
-      If defined then a custom character set to use with the MySQL server.
+      If defined then a custom character set to use with the MariaDB or MySQL server.
   - name: ssl
     type: Boolean
     required: false
     default: 'No'
     added: 3.15.0
     description: |-
-      Whether to connect to the MySQL server using TLS (SSL).
+      Whether to connect to the MariaDB or MySQL server using TLS (SSL).
   details: ""
   example: |-
     ```xml

--- a/docs/4/modules/mysql.yml
+++ b/docs/4/modules/mysql.yml
@@ -4,19 +4,19 @@ depends_on:
   what: a third-party library ([libmysqlclient](https://dev.mysql.com/downloads/connector/c/))
 
 description: |-
-  This module provides the ability for SQL modules to query a MySQL database.
+  This module provides the ability for SQL modules to query a MariaDB or MySQL database.
 
 configuration:
 - name: database
   description: |-
-    The `<database>` tag defines a MySQL database to connect to. This tag can be defined as many times as required.
+    The `<database>` tag defines a MariaDB or MySQL database to connect to. This tag can be defined as many times as required.
   attributes:
   - name: module
     type: Text
     required: true
     default: null
     description: |-
-      *This MUST be set to "mysql" to connect to a MySQL database.*
+      *This MUST be set to "mysql" to connect to a MariaDB or MySQL database.*
   - name: id
     type: Text
     required: true
@@ -28,37 +28,37 @@ configuration:
     required: true
     default: null
     description: |-
-      The hostname or IP address of a MySQL server.
+      The hostname or IP address of a MariaDB or MySQL server.
   - name: port
     type: Number
     required: true
     default: null
     description: |-
-      The port on which the MySQL server is listening.
+      The port on which the MariaDB or MySQL server is listening.
   - name: user
     type: Text
     required: true
     default: null
     description: |-
-      The username to log into the MySQL server with.
+      The username to log into the MariaDB or MySQL server with.
   - name: pass
     type: Text
     required: true
     default: null
     description: |-
-      The password to log into the MySQL server with.
+      The password to log into the MariaDB or MySQL server with.
   - name: name
     type: Text
     required: true
     default: null
     description: |-
-      The name of the MySQL database to use.
+      The name of the MariaDB or MySQL database to use.
   - name: charset
     type: Text
     required: false
     default: null
     description: |-
-      If defined then a custom character set to use with the MySQL server.
+      If defined then a custom character set to use with the MariaDB or MySQL server.
   - name: srv
     type: Boolean
     required: false


### PR DESCRIPTION
Suggesting to add MariaDB to MySQL module documentation: https://docs.inspircd.org/4/modules/mysql/ and https://docs.inspircd.org/3/modules/mysql/. As per discussion https://github.com/inspircd/inspircd-docs/issues/239

Considering MariaDB has been default in most distros for a while, e.g.  n Debian since 2017 and on Fedora since 2015 (if I remember correctly). If you are not getting bug reports from Debian/Fedora users, then inspircd most probably does not have any major issues with MariaDB - except what mentioned in discussion about srv, tls and version check. 

Version 4 mentions srv and tlc options requiring version 8.0 of MySQL. Would be nice if there were equivalents in MariaDB for that. 